### PR TITLE
Update check around empty headers to drop the header instead of asserting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -415,8 +415,8 @@ export class SimpleWebRequest<T> {
             }
             assert.ok(!headersCheck[headerLower], 'Setting duplicate header key: ' + headersCheck[headerLower] + ' and ' + key);
 
-            if (!val) {
-                assert.ok(false, 'Empty header being sent for key: ' + key + '. This will crash Android RN if let through.');
+            if (val === undefined || val === null) {
+                console.warn('Tried to set header "' + key + '" on request with "' + val + '" value, header will be dropped');
                 return;
             }
 


### PR DESCRIPTION

Passing empty headers into RN Android no longer crashes, but it does drop the entire header array, so we should still protect against that.
The existing check was incorrectly matching empty string in the assert.
https://github.com/facebook/react-native/commit/191db9034598d75ba44adf613999c807a1efe457