### PR TITLE
[0.0.18] Better headers flow. Headers are now updated right before fi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/GenericRestClient.ts
+++ b/src/GenericRestClient.ts
@@ -63,21 +63,21 @@ export class GenericRestClient {
 
     private _performApiCallInternal<T>(apiPath: string, action: HttpAction, options: ApiCallOptions)
             : SyncTasks.Promise<WebResponse<T>> {
-        if (!options.headers) {
-            options.headers = this._getHeaders(options);
-        }
 
         if (options.eTag) {
-            options.headers['If-None-Match'] = options.eTag;
+            if (!options.augmentHeaders) {
+                options.augmentHeaders = {};
+            }
+            options.augmentHeaders['If-None-Match'] = options.eTag;
         }
-
+        
         if (!options.contentType) {
             options.contentType = _.isString(options.sendData) ? 'form' : 'json';
         }
 
         const finalUrl = options.excludeEndpointUrl ? apiPath : this._endpointUrl + apiPath;
 
-        let request = new SimpleWebRequest<T>(action, finalUrl, options);
+        let request = new SimpleWebRequest<T>(action, finalUrl, options, () => this._getHeaders(options));
         return request.start().then(resp => {
             this._processSuccessResponse<T>(resp);
             return resp;

--- a/src/lodashMini.ts
+++ b/src/lodashMini.ts
@@ -8,6 +8,7 @@
 */
 
 import clone = require('lodash/clone');
+import cloneDeep = require('lodash/cloneDeep');
 import isString = require('lodash/isString');
 import defaults = require('lodash/defaults');
 import remove = require('lodash/remove');
@@ -17,6 +18,7 @@ import forEach = require('lodash/forEach');
 import map = require('lodash/map');
 import isObject = require('lodash/isObject');
 import pull = require('lodash/pull');
+import extend = require('lodash/extend');
 
 export interface Dictionary<T> {
     [index: string]: T;
@@ -24,6 +26,7 @@ export interface Dictionary<T> {
 
 export {
     clone,
+    cloneDeep,
     isString,
     defaults,
     remove,
@@ -32,5 +35,6 @@ export {
     forEach,
     map,
     isObject,
-    pull
+    pull,
+    extend
 };


### PR DESCRIPTION
…ring each attempt instead of using a static set of headers on construction. Use options.overrideGetHeaders for a static set of headers (replacing the deprecated options.headers).

Note: this is backwards compatible with anyone assuming version 0.0.17. The getHeaders() constructor parameter is optional, and options.headers is still used (if provided).