### PR TITLE
Allow aborted requested to be handled by custom policy

### DIFF
--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -128,8 +128,8 @@ export let SimpleWebRequestOptions: SimpleWebRequestOptions = {
 };
 
 export function DefaultErrorHandler(webRequest: SimpleWebRequest<any>, errResp: WebErrorResponse) {
-    if (errResp.statusCode >= 400 && errResp.statusCode < 600) {
-        // Fail 4xx/5xx requests immediately. These are permenent failures, and shouldn't have retry logic applied to them.
+    if (!errResp.statusCode || errResp.statusCode >= 400 && errResp.statusCode < 600) {
+        // Fail 0/4xx/5xx requests immediately. These are permenent failures, and shouldn't have retry logic applied to them.
         return ErrorHandlingType.DoNotRetry;
     }
 

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -128,8 +128,8 @@ export let SimpleWebRequestOptions: SimpleWebRequestOptions = {
 };
 
 export function DefaultErrorHandler(webRequest: SimpleWebRequest<any>, errResp: WebErrorResponse) {
-    if (!errResp.statusCode || errResp.statusCode >= 400 && errResp.statusCode < 600) {
-        // Fail 0/4xx/5xx requests immediately. These are permenent failures, and shouldn't have retry logic applied to them.
+    if (errResp.canceled || !errResp.statusCode || errResp.statusCode >= 400 && errResp.statusCode < 600) {
+        // Fail canceled/0/4xx/5xx requests immediately. These are permenent failures, and shouldn't have retry logic applied to them.
         return ErrorHandlingType.DoNotRetry;
     }
 


### PR DESCRIPTION
- Allow customErrorHandler on aborted call
- Allow retry on aborted call
- Fix: Avoid duplicate call to _respond when the xhr was manually aborted (ie: when timeout is specified)