### PR TITLE
Revert recent behavioural change to request aborting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -203,10 +203,10 @@ export class SimpleWebRequest<T> {
         if (this._xhr) {
             // Abort the in-flight request
             this._xhr.abort();
-        } else {
-            // this._xhr.abort() trigger this._xhr.onAbort() callback which already call _respond()
-            this._respond();
         }
+
+        // Cannot rely on this._xhr.abort() to trigger this._xhr.onAbort() synchronously, thus we must trigger an early response here
+        this._respond();
     }
 
     start(): SyncTasks.Promise<WebResponse<T>> {

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -200,13 +200,13 @@ export class SimpleWebRequest<T> {
             return;
         }
 
+        // Cannot rely on this._xhr.abort() to trigger this._xhr.onAbort() synchronously, thus we must trigger an early response here
+        this._respond();
+
         if (this._xhr) {
             // Abort the in-flight request
             this._xhr.abort();
         }
-
-        // Cannot rely on this._xhr.abort() to trigger this._xhr.onAbort() synchronously, thus we must trigger an early response here
-        this._respond();
     }
 
     start(): SyncTasks.Promise<WebResponse<T>> {
@@ -637,7 +637,15 @@ export class SimpleWebRequest<T> {
                 this._finishHandled = false;
 
                 // Clear the XHR since we technically just haven't started again yet...
-                this._xhr = undefined;
+                if (this._xhr) {
+                    this._xhr.onabort = null;
+                    this._xhr.onerror = null;
+                    this._xhr.onload = null;
+                    this._xhr.onprogress = null;
+                    this._xhr.onreadystatechange = null;
+                    this._xhr.ontimeout = null;
+                    this._xhr = undefined;
+                }
 
                 if (handleResponse === ErrorHandlingType.PauseUntilResumed) {
                     this._paused = true;


### PR DESCRIPTION
On React Native, abort requires a call across the bridge making it more async than a typical browser. Since promise resolution is used to determine when a network request is completed (including the abort/cancel case), it's possible for abort() to be called twice OR for a network request success to arrive before the abort is fully processed.