### PR TITLE
0.1.3: Expose request bits from WebResponse...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {


### PR DESCRIPTION
The exact headers are not known until the request is sent, so the caller does not have them (except in simple cases). Also, the request options are useful to return in case the 'caller' is a helper function that creates the request and thus the original caller does not necessarily have that information.