### PR TITLE
0.1.4: Made WebResponse's request bits optional to allow transport-ag…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -15,8 +15,8 @@ import { ExponentialTime } from './ExponentialTime';
 export interface WebResponseBase {
     url: string;
     method: string;
-    requestOptions: WebRequestOptions;
-    requestHeaders: _.Dictionary<string>;
+    requestOptions?: WebRequestOptions;
+    requestHeaders?: _.Dictionary<string>;
     statusCode: number;
     statusText: string|undefined;
     headers: _.Dictionary<string>;


### PR DESCRIPTION
…nostic usage of the interfaces. For example, WebSockets do not have the same type of request options or use headers the same way.