### PR TITLE
Changed exported const enum ErrorHandlingType to regular enum.

### DIFF
--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -52,7 +52,7 @@ export enum WebRequestPriority {
     Critical = 4
 }
 
-export const enum ErrorHandlingType {
+export enum ErrorHandlingType {
     // Ignore retry policy, if any, and fail immediately
     DoNotRetry,
 


### PR DESCRIPTION
Const enums are not supported with --isolatedModules typescript flag which can improve compilation significantly.