### PR TITLE
Feature/add default template parameters to web response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/GenericRestClient.ts
+++ b/src/GenericRestClient.ts
@@ -18,8 +18,8 @@ import {
 export type HttpAction = 'POST'|'GET'|'PUT'|'DELETE'|'PATCH';
 
 export interface ApiCallOptions extends WebRequestOptions {
-    excludeEndpointUrl?: boolean;
     backendUrl?: string;
+    excludeEndpointUrl?: boolean;
     eTag?: string;
 }
 

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -13,7 +13,7 @@ import SyncTasks = require('synctasks');
 import { ExponentialTime } from './ExponentialTime';
 
 export interface Headers {
-    [header: string]: string|undefined;
+    [header: string]: string;
 }
 
 export interface WebTransportResponseBase {
@@ -34,7 +34,7 @@ export interface WebTransportErrorResponse extends WebTransportResponseBase {
     timedOut: boolean;
 }
 
-export interface RestRequestInResponse<TOptions> {
+export interface RestRequestInResponse<TOptions = WebRequestOptions> {
     requestOptions: TOptions;
     requestHeaders: Headers;
 }
@@ -117,15 +117,15 @@ export interface WebRequestOptions {
     augmentErrorResponse?: (resp: WebErrorResponse) => void;
 }
 
-function isJsonContentType(ct: string|undefined) {
+function isJsonContentType(ct: string) {
     return ct && ct.indexOf('application/json') === 0;
 }
 
-function isFormContentType(ct: string|undefined) {
+function isFormContentType(ct: string) {
     return ct && ct.indexOf('application/x-www-form-urlencoded') === 0;
 }
 
-function isFormDataContentType(ct: string|undefined) {
+function isFormDataContentType(ct: string) {
     return ct && ct.indexOf('multipart/form-data') === 0;
 }
 

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -425,8 +425,8 @@ export abstract class SimpleWebRequestBase {
         }
     }
 
-    getRequestHeaders(): { [header: string]: string } {
-        let headers: { [header: string]: string } = {};
+    getRequestHeaders(): Headers {
+        let headers: Headers = {};
 
         if (this._getHeaders && !this._options.overrideGetHeaders && !this._options.headers) {
             headers = _.extend(headers, this._getHeaders());
@@ -523,7 +523,7 @@ export class SimpleWebRequest<ResponseBody, RequestOptions = WebRequestOptions> 
 
     private _deferred: SyncTasks.Deferred<WebResponse<ResponseBody, RequestOptions>>;
 
-    constructor(action: string, url: string, options: RequestOptions, getHeaders?: () => _.Dictionary<string>) {
+    constructor(action: string, url: string, options: RequestOptions, getHeaders?: () => Headers) {
         super(action, url, options, getHeaders);
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,11 +12,11 @@
         "strictNullChecks": true,
         "forceConsistentCasingInFileNames": true
     },
-    
-    "filesGlob": [
-        "src/**/*{ts,tsx}"
+
+    "include": [
+        "src/**/*"
     ],
-    
+
     "exclude": [
         "dist",
         "node_modules"

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
     "forin": true,
     "indent": [true, "spaces"],
     "label-position": true,
-    "max-line-length": [ true, 140 ],
+    "max-line-length": [true, 140],
     "no-arg": true,
     "no-bitwise": false,
     "no-console": [true,


### PR DESCRIPTION
> WebResponse does not know about additional options, which exist in `GenericRestClient`
```
export interface ApiCallOptions extends WebRequestOptions {
   backendUrl?: string;
   excludeEndpointUrl?: boolean;
   eTag?: string;
}
```

https://codesandbox.io/s/v6jyl7n1m0