### PR TITLE
Add responseType 'text'

### DIFF
--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -514,6 +514,10 @@ export abstract class SimpleWebRequestBase<TOptions extends WebRequestOptions = 
             return 'document';
         }
 
+        if (acceptType === 'text/plain') {
+            return 'text';
+        }
+
         return 'json';
     }
 


### PR DESCRIPTION
The default 'json' causes this._xhr.response to be null.