### PR TITLE
Fix an assertion if a request with timeout receives 2 callbacks from …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {


### PR DESCRIPTION
…the Browser/OS.

This resulted in _respond being called twice, which (if the correct retry policy was applied) would result in the request being enqueued twice & this two timeout timers were setup.