### PR TITLE
Prevent against potential double abort scenario

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -313,7 +313,7 @@ export abstract class SimpleWebRequestBase<TOptions extends WebRequestOptions = 
                     return;
                 }
 
-                if (this._xhr.readyState === 3 && this._options.streamingDownloadProgress) {
+                if (this._xhr.readyState === 3 && this._options.streamingDownloadProgress && !this._aborted) {
                     // This callback may result in cancelling the connection, so keep that in mind with any handling after it
                     // if we decide to stop using the return after this someday down the line.  i.e. this._xhr may be undefined
                     // when we come back from this call.
@@ -346,7 +346,7 @@ export abstract class SimpleWebRequestBase<TOptions extends WebRequestOptions = 
                     return;
                 }
 
-                if (this._xhr.readyState === 3 && this._options.streamingDownloadProgress) {
+                if (this._xhr.readyState === 3 && this._options.streamingDownloadProgress && !this._aborted) {
                     // This callback may result in cancelling the connection, so keep that in mind with any handling after it
                     // if we decide to stop using the return after this someday down the line.  i.e. this._xhr may be undefined
                     // when we come back from this call.


### PR DESCRIPTION
If a request is already aborted, don't send any streamingDownloadProgress data, cancel means we don't care anymore
This prevents a case where two callbacks may both try to cancel the promise (and abort the request) causing an exception