### PR TITLE
Periodically check the list of running request to see if any of them …

### DIFF
--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -179,7 +179,7 @@ let blockedList: SimpleWebRequestBase[] = [];
 // List of executing (non-finished) requests -- only to keep track of number of requests to compare to the max
 let executingList: SimpleWebRequestBase[] = [];
 
-let hungReqeustCleanupTimer: number | undefined;
+let hungRequestCleanupTimer: number | undefined;
 const hungRequestCleanupInterval = 30000;
 
 // Feature flag checkers for whether the current environment supports various types of XMLHttpRequest features
@@ -242,17 +242,17 @@ export abstract class SimpleWebRequestBase<TOptions extends WebRequestOptions = 
 
     private static _scheduleHungRequestCleanupIfNeeded() {
         // Schedule a cleanup timer if needed
-        if (executingList.length > 0 && hungReqeustCleanupTimer === undefined) {
-            hungReqeustCleanupTimer = SimpleWebRequestOptions.setTimeout(this._hungRequestCleanupTimerCallback,
+        if (executingList.length > 0 && hungRequestCleanupTimer === undefined) {
+            hungRequestCleanupTimer = SimpleWebRequestOptions.setTimeout(this._hungRequestCleanupTimerCallback,
                 hungRequestCleanupInterval);
-        } else if (executingList.length === 0 && hungReqeustCleanupTimer) {
-            SimpleWebRequestOptions.clearTimeout(hungReqeustCleanupTimer);
-            hungReqeustCleanupTimer = undefined;
+        } else if (executingList.length === 0 && hungRequestCleanupTimer) {
+            SimpleWebRequestOptions.clearTimeout(hungRequestCleanupTimer);
+            hungRequestCleanupTimer = undefined;
         }
     }
 
     private static _hungRequestCleanupTimerCallback = () => {
-        hungReqeustCleanupTimer = undefined;
+        hungRequestCleanupTimer = undefined;
         executingList.filter(request => {
             if (request._xhr && request._xhr.readyState === 4) {
                 // We've seen cases where requests have reached completion but callbacks haven't been called (typically during failed

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -141,7 +141,7 @@ export interface ISimpleWebRequestOptions {
 
     // We've seen cases where requests have reached completion but callbacks haven't been called (typically during failed
     // CORS preflight) Directly call the respond function to kick these requests and unblock the reserved slot in our queues
-    HungRequestCleanupIntervaMs: number;
+    HungRequestCleanupIntervalMs: number;
 
     // Use this to shim calls to setTimeout/clearTimeout with any other service/local function you want.
     setTimeout: (callback: () => void, timeoutMs?: number) => number;
@@ -150,7 +150,7 @@ export interface ISimpleWebRequestOptions {
 
 export let SimpleWebRequestOptions: ISimpleWebRequestOptions = {
     MaxSimultaneousRequests: 5,
-    HungRequestCleanupIntervaMs: 10000,
+    HungRequestCleanupIntervalMs: 10000,
 
     setTimeout: (callback: () => void, timeoutMs?: number) => window.setTimeout(callback, timeoutMs),
     clearTimeout: (id: number) => window.clearTimeout(id)
@@ -248,7 +248,7 @@ export abstract class SimpleWebRequestBase<TOptions extends WebRequestOptions = 
         // Schedule a cleanup timer if needed
         if (executingList.length > 0 && hungRequestCleanupTimer === undefined) {
             hungRequestCleanupTimer = SimpleWebRequestOptions.setTimeout(this._hungRequestCleanupTimerCallback,
-                SimpleWebRequestOptions.HungRequestCleanupIntervaMs);
+                SimpleWebRequestOptions.HungRequestCleanupIntervalMs);
         } else if (executingList.length === 0 && hungRequestCleanupTimer) {
             SimpleWebRequestOptions.clearTimeout(hungRequestCleanupTimer);
             hungRequestCleanupTimer = undefined;


### PR DESCRIPTION
…have completed & not reported their changed status

We've seen cases of CORS preflight (OPTIONS) requests failing but never calling the onLoad/onError callbacks
Setup a periodic timer to check on the state of running requests & force completion if readyState has changed to 4