### PR TITLE
Reset the timedOut flag on retry

### DIFF
--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -857,6 +857,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
                 }
 
                 this._aborted = false;
+                this._timedOut = false;
                 this._finishHandled = false;
 
                 // Clear the XHR since we technically just haven't started again yet...


### PR DESCRIPTION
If the request times out, is retried, and fails, it was always being rejected with `timedOut: true` even if the last try failed for another reason.