### PR TITLE
Added new flag to response which indicates whether the json parsing has failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.2.12",
+  "version": "0.2.11",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplerestclients",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "A library of components for accessing RESTful services with javascript/typescript.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -29,7 +29,7 @@ export interface WebTransportResponseBase {
     statusCode: number;
     statusText: string | undefined;
     headers: Headers;
-    responseParsingException?: Exception;
+    responseParsingException?: Error;
 }
 
 export interface WebTransportResponse<TBody> extends WebTransportResponseBase {
@@ -138,17 +138,6 @@ function isFormContentType(ct: string): boolean {
 
 function isFormDataContentType(ct: string): boolean {
     return !!ct && ct.indexOf('multipart/form-data') === 0;
-}
-
-function createException(error: Error): Exception | undefined {
-    if (error instanceof Error) {
-        return {
-            name: error.name,
-            message: error.message,
-        };
-    }
-
-    return undefined;
 }
 
 export const DefaultOptions: WebRequestOptions = {
@@ -779,7 +768,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
 
         let headers: Headers = {};
         let body: any;
-        let responseParsingException: Exception | undefined = undefined;
+        let responseParsingException: Error | undefined = undefined;
 
         // Build the response info
         if (this._xhr) {
@@ -822,7 +811,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
                             // If a service returns invalid JSON in a payload, we can end up here - don't crash
                             // responseParsingException flag will indicate that we got response from the server that was corrupted.
                             // This will be manifested as null on receipient side and flag can help in understanding the problem.
-                            responseParsingException = createException(ex);
+                            responseParsingException = ex;
                             console.warn('Failed to parse XHR JSON response');
                         }
                     }

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -140,7 +140,7 @@ function isFormDataContentType(ct: string): boolean {
     return !!ct && ct.indexOf('multipart/form-data') === 0;
 }
 
-export function serializeError(error: Error): Exception | undefined {
+function createException(error: Error): Exception | undefined {
     if (error instanceof Error) {
         return {
             name: error.name,
@@ -822,7 +822,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
                             // If a service returns invalid JSON in a payload, we can end up here - don't crash
                             // responseParsingException flag will indicate that we got response from the server that was corrupted.
                             // This will be manifested as null on receipient side and flag can help in understanding the problem.
-                            responseParsingException = serializeError(ex);
+                            responseParsingException = createException(ex);
                             console.warn('Failed to parse XHR JSON response');
                         }
                     }

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -18,11 +18,6 @@ interface Dictionary<T> {
 export interface Headers extends Dictionary<string> {}
 export interface Params extends Dictionary<any> {}
 
-export interface Exception {
-    message: string;
-    name: string;
-}
-
 export interface WebTransportResponseBase {
     url: string;
     method: string;

--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -24,6 +24,7 @@ export interface WebTransportResponseBase {
     statusCode: number;
     statusText: string | undefined;
     headers: Headers;
+    responseParsingFailed: boolean;
 }
 
 export interface WebTransportResponse<TBody> extends WebTransportResponseBase {
@@ -762,6 +763,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
 
         let headers: Headers = {};
         let body: any;
+        let responseParsingFailed = false;
 
         // Build the response info
         if (this._xhr) {
@@ -802,6 +804,9 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
                             body = JSON.parse(this._xhr.responseText);
                         } catch (ex) {
                             // If a service returns invalid JSON in a payload, we can end up here - don't crash
+                            // responseParsingFailed flag will indicate that we got response from the server that was corrupted.
+                            // This will be manifested as null on receipient side and flag can help in understanding the problem.
+                            responseParsingFailed = true;
                             console.warn('Failed to parse XHR JSON response');
                         }
                     }
@@ -820,6 +825,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
                 statusText: statusText,
                 headers: headers,
                 body: body as TBody,
+                responseParsingFailed: responseParsingFailed,
             };
 
             this._deferred.resolve(resp);
@@ -835,6 +841,7 @@ export class SimpleWebRequest<TBody, TOptions extends WebRequestOptions = WebReq
                 body: body,
                 canceled: this._aborted,
                 timedOut: this._timedOut,
+                responseParsingFailed: responseParsingFailed,
             };
 
             if (this._options.augmentErrorResponse) {

--- a/test/GenericRestClient.spec.ts
+++ b/test/GenericRestClient.spec.ts
@@ -68,6 +68,7 @@ describe('GenericRestClient', () => {
         };
         const path = `/get/${id}`;
         const url = BASE_URL + path;
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestHeaders: { 'Accept': 'application/json' },
@@ -75,6 +76,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
+            responseParsingFailed,
         };
 
         http.performApiGetDetailed(path, { contentType: 'json' })
@@ -130,6 +132,7 @@ describe('GenericRestClient', () => {
         const body = { ...sendData, id: faker.random.uuid() };
         const path = '/post';
         const url = BASE_URL + path;
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -137,6 +140,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
+            responseParsingFailed,
         };
 
         http.performApiPostDetailed(path, sendData, { contentType: 'json' })
@@ -189,6 +193,7 @@ describe('GenericRestClient', () => {
         const body = { ...sendData, id: faker.random.uuid() };
         const path = `/patch/${id}`;
         const url = BASE_URL + path;
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -196,6 +201,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
+            responseParsingFailed,
         };
 
         http.performApiPutDetailed(path, sendData, { contentType: 'json' })
@@ -255,6 +261,7 @@ describe('GenericRestClient', () => {
         const body = { ...sendData, id: faker.random.uuid() };
         const path = `/patch/${id}`;
         const url = BASE_URL + path;
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -262,6 +269,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
+            responseParsingFailed,
         };
 
         http.performApiPatchDetailed(path, sendData, { contentType: 'json' })
@@ -311,6 +319,7 @@ describe('GenericRestClient', () => {
         const body = {};
         const path = `/delete/${id}`;
         const url = BASE_URL + path;
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -318,6 +327,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
+            responseParsingFailed,
         };
 
         http.performApiDeleteDetailed(path, sendData, { contentType: 'json' })

--- a/test/GenericRestClient.spec.ts
+++ b/test/GenericRestClient.spec.ts
@@ -68,7 +68,7 @@ describe('GenericRestClient', () => {
         };
         const path = `/get/${id}`;
         const url = BASE_URL + path;
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestHeaders: { 'Accept': 'application/json' },
@@ -76,7 +76,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         http.performApiGetDetailed(path, { contentType: 'json' })
@@ -132,7 +132,7 @@ describe('GenericRestClient', () => {
         const body = { ...sendData, id: faker.random.uuid() };
         const path = '/post';
         const url = BASE_URL + path;
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -140,7 +140,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         http.performApiPostDetailed(path, sendData, { contentType: 'json' })
@@ -193,7 +193,7 @@ describe('GenericRestClient', () => {
         const body = { ...sendData, id: faker.random.uuid() };
         const path = `/patch/${id}`;
         const url = BASE_URL + path;
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -201,7 +201,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         http.performApiPutDetailed(path, sendData, { contentType: 'json' })
@@ -261,7 +261,7 @@ describe('GenericRestClient', () => {
         const body = { ...sendData, id: faker.random.uuid() };
         const path = `/patch/${id}`;
         const url = BASE_URL + path;
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -269,7 +269,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         http.performApiPatchDetailed(path, sendData, { contentType: 'json' })
@@ -319,7 +319,7 @@ describe('GenericRestClient', () => {
         const body = {};
         const path = `/delete/${id}`;
         const url = BASE_URL + path;
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...REQUEST_OPTIONS, sendData },
@@ -327,7 +327,7 @@ describe('GenericRestClient', () => {
             method,
             body,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         http.performApiDeleteDetailed(path, sendData, { contentType: 'json' })

--- a/test/SimpleWebRequest.spec.ts
+++ b/test/SimpleWebRequest.spec.ts
@@ -30,14 +30,14 @@ describe('SimpleWebRequest', () => {
         const onSuccess = jasmine.createSpy('onSuccess');
         const method = 'GET';
         const url = faker.internet.url();
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...requestOptions, priority: WebRequestPriority.Normal },
             requestHeaders,
             method,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         new SimpleWebRequest<string>(method, url, requestOptions)
@@ -64,7 +64,7 @@ describe('SimpleWebRequest', () => {
         const method = 'POST';
         const body = { ...sendData, id: faker.random.uuid() };
         const url = faker.internet.url();
-        const responseParsingFailed = false;
+        const responseParsingException = undefined;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...requestOptions, priority: WebRequestPriority.Normal },
@@ -72,7 +72,7 @@ describe('SimpleWebRequest', () => {
             method,
             body,
             url,
-            responseParsingFailed,
+            responseParsingException,
         };
 
         new SimpleWebRequest<string>(method, url, requestOptions)

--- a/test/SimpleWebRequest.spec.ts
+++ b/test/SimpleWebRequest.spec.ts
@@ -30,12 +30,14 @@ describe('SimpleWebRequest', () => {
         const onSuccess = jasmine.createSpy('onSuccess');
         const method = 'GET';
         const url = faker.internet.url();
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...requestOptions, priority: WebRequestPriority.Normal },
             requestHeaders,
             method,
             url,
+            responseParsingFailed,
         };
 
         new SimpleWebRequest<string>(method, url, requestOptions)
@@ -62,6 +64,7 @@ describe('SimpleWebRequest', () => {
         const method = 'POST';
         const body = { ...sendData, id: faker.random.uuid() };
         const url = faker.internet.url();
+        const responseParsingFailed = false;
         const response = {
             ...DETAILED_RESPONSE,
             requestOptions: { ...requestOptions, priority: WebRequestPriority.Normal },
@@ -69,6 +72,7 @@ describe('SimpleWebRequest', () => {
             method,
             body,
             url,
+            responseParsingFailed,
         };
 
         new SimpleWebRequest<string>(method, url, requestOptions)


### PR DESCRIPTION
Added new flag to response which indicates whether the json parsing has failed

Sometimes server sends json response and client receives `null`. In order to diagnose what happened it would be useful to have the information whether the json parsing process has failed.
This way we can distinguish real `null` and corrupted server response.