### PR TITLE
Adding Retry for statusCode 0

### DIFF
--- a/src/SimpleWebRequest.ts
+++ b/src/SimpleWebRequest.ts
@@ -160,8 +160,8 @@ export let SimpleWebRequestOptions: ISimpleWebRequestOptions = {
 };
 
 export function DefaultErrorHandler(webRequest: SimpleWebRequestBase, errResp: WebTransportErrorResponse): ErrorHandlingType {
-    if (errResp.canceled || !errResp.statusCode || errResp.statusCode >= 400 && errResp.statusCode < 600) {
-        // Fail canceled/0/4xx/5xx requests immediately.
+    if (errResp.canceled || errResp.statusCode >= 400 && errResp.statusCode < 600) {
+        // Fail canceled/4xx/5xx requests immediately.
         // These are permenent failures, and shouldn't have retry logic applied to them.
         return ErrorHandlingType.DoNotRetry;
     }


### PR DESCRIPTION
### **Adding default retry for status Code 0**

As investigated on a project with millions of users around the world, we found that status code 0 is not a permanent failure, and we should retry on them...

status code 0 represents a list of retriable things like: -

1. _DNS_: sometimes requests failed because of DNS, and we need a retry on them; and that is not permanent.  
2. _TCP_: we found a huge request failed on tcp connection with the server and retrying them helps.
3. _TLS_: this is tls handshake connection with the server

due to JavaScript limitations, they actually hide the actual reason for status code 0 and we can't capture the exception from the onerror method to differentiate different types of error code 0; some of them are actually will be no internet and some others will be normal retriable errors like specified above (DNS, TCP and TLS handshake)

we can override the errorDefaultHandler, but this is counterintuitive for the default error handler, and we actually didn't notice there was no retry or this is permanent for a very long time.